### PR TITLE
Clean Dockerfile and bump NodeBB to v0.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,16 +10,19 @@ FROM dockerfile/ubuntu
 # Install Node.js
 RUN apt-get update
 RUN apt-get upgrade -y
-RUN apt-get install nodejs-legacy -y
-RUN apt-get install npm -y
-RUN cd /opt && git clone https://github.com/NodeBB/NodeBB.git nodebb
-RUN cd /opt/nodebb && npm install
-RUN apt-get install imagemagick -y
+RUN apt-get install nodejs-legacy npm imagemagick -y
 
-VOLUME /opt/nodebb
+RUN cd /opt && git clone https://github.com/NodeBB/NodeBB.git nodebb
 
 # Define working directory.
 WORKDIR /opt/nodebb
+
+#Bump version nodebb
+RUN git checkout v0.6.1
+
+RUN npm install
+
+VOLUME /opt/nodebb
 
 EXPOSE 4567
 


### PR DESCRIPTION
I just clean the apt install to avoid many created container.

I define the working dir earlier for next commands simply

And bump version of NodeBB to the latest (v0.6.1)